### PR TITLE
Make image compatible with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN apk --update --no-cache add fuse alpine-sdk automake autoconf libxml2-dev fu
     rm -rf /var/cache/apk/*; \
     apk del git automake autoconf;
 
-RUN mkdir -p "$MNT_POINT"
+COPY ./run.sh /run.sh
+RUN chmod 755 /run.sh
+CMD /run.sh
 
-CMD echo "${AWS_KEY}:${AWS_SECRET_KEY}" > /etc/passwd-s3fs && \
-    chmod 0400 /etc/passwd-s3fs && \
-    /usr/bin/s3fs $S3_BUCKET $MNT_POINT -f -o endpoint=${S3_REGION},allow_other,use_cache=/tmp,max_stat_cache_size=1000,stat_cache_expire=900,retries=5,connect_timeout=10

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mkdir -p "${MNT_POINT}"
+echo "${AWS_KEY}:${AWS_SECRET_KEY}" > /etc/passwd-s3fs
+chmod 0400 /etc/passwd-s3fs
+/usr/bin/s3fs $S3_BUCKET $MNT_POINT -f -o endpoint=${S3_REGION},allow_other,use_cache=/tmp,max_stat_cache_size=1000,stat_cache_expire=900,retries=5,connect_timeout=10
+


### PR DESCRIPTION
Hey,
This minor edit makes this image also work for docker-compose.

Example usage:

```
version: '3.6'

services:
  s3:
    # image: your-image/kube-s3:1.0
    build: .
    restart: always
    container_name: s3
    privileged: true
    environment:
      - MNT_POINT=/mnt/data-s3fs
      - S3_BUCKET=name-of-bucket
      - AWS_KEY=xxxxxxxxxxxxxxxxxxxx
      - AWS_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    tty: true
```