### PR TITLE
Fixes no matches for kind "DaemonSet" in version "extensions/v1beta1"

### DIFF
--- a/yaml/daemonset.yaml
+++ b/yaml/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:


### PR DESCRIPTION
Taken solution from here:
https://github.com/gluster/gluster-kubernetes/issues/627

The API versions have been updated