### PR TITLE
The spec.Selector needs to be explicitly set.

### DIFF
--- a/yaml/daemonset.yaml
+++ b/yaml/daemonset.yaml
@@ -5,6 +5,9 @@ metadata:
     app: s3-provider
   name: s3-provider
 spec:
+  selector:
+  matchLabels:
+      app: s3-provider
   template:
     metadata:
       labels:


### PR DESCRIPTION
See:
https://www.studytonight.com/post/solved-missing-required-field-selector-in-kubernetes