### PR TITLE
Fix error while daemon starting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ RUN apk --update add bash fuse libcurl libxml2 libstdc++ libgcc alpine-sdk autom
 RUN sed -i s/"#user_allow_other"/"user_allow_other"/g /etc/fuse.conf
 
 COPY docker-entrypoint.sh /
+RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 CMD /docker-entrypoint.sh


### PR DESCRIPTION
Error ocurs when starting daemon `s3-provider` : `Back-off restarting failed container`

Add execute permission for `docker-entrypoint.sh` can fix this error.